### PR TITLE
Fix bazel warnings

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
-load("@rules_python//python:defs.bzl", "py_library", "py_test")
 load("@pyprotoc_plugin_deps//:requirements.bzl", "requirement")
+load("@rules_python//python:defs.bzl", "py_library", "py_test")
 
 py_library(
     name = "pyprotoc_plugin",

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -6,4 +6,5 @@ def deps(repo_mapping = {}):
     pip_install(
         name = "pyprotoc_plugin_deps",
         requirements = "@com_github_reboot_dev_pyprotoc_plugin//:requirements.txt",
+        repo_mapping = repo_mapping,
     )

--- a/rules.bzl
+++ b/rules.bzl
@@ -1,3 +1,5 @@
+"""Defines rules to create pyprotoc-based bazel rules."""
+
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 
 def _get_proto_sources(context):
@@ -111,12 +113,9 @@ def _protoc_plugin_rule_implementation(context):
         use_default_shell_env = True,
     )
 
-    # TODO(alexmc): This returns a legacy provider, which is deprecated:
-    # https://docs.bazel.build/versions/main/skylark/rules.html#migrating-from-legacy-providers
-    # Switch to using modern providers.
-    return struct(
+    return [DefaultInfo(
         files = depset(output_files),
-    )
+    )]
 
 def create_protoc_plugin_rule(plugin_label, extensions):
     return rule(


### PR DESCRIPTION
TESTED=ran `submodules/dev-tools/check-code-style/check_style_bzl.sh` on
a branch with https://github.com/3rdparty/eventuals/pull/288 which adds
this repo as a submodule of eventuals.
