### PR TITLE
Add pyprotoc-plugin tests: sample python code gen

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,1 @@
+test --test_output=errors

--- a/bazel/deps.bzl
+++ b/bazel/deps.bzl
@@ -1,5 +1,6 @@
 """Dependency specific initialization."""
 
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 load("@rules_python//python:pip.bzl", "pip_install")
 
 def deps(repo_mapping = {}):
@@ -8,3 +9,5 @@ def deps(repo_mapping = {}):
         requirements = "@com_github_reboot_dev_pyprotoc_plugin//:requirements.txt",
         repo_mapping = repo_mapping,
     )
+
+    protobuf_deps()

--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -20,6 +20,16 @@ def repos(external = True, repo_mapping = {}):
         repo_mapping = repo_mapping,
     )
 
+    if "com_google_protobuf" not in native.existing_rules():
+        git_repository(
+            name = "com_google_protobuf",
+            remote = "https://github.com/protocolbuffers/protobuf",
+            # Release 3.20.0.
+            commit = "bc799d78f81115940eec953e2937245c70e3e6e4",
+            shallow_since = "1648147893 -0700",
+            repo_mapping = repo_mapping,
+        )
+
     if external and "com_github_reboot_dev_pyprotoc_plugin" not in native.existing_rules():
         git_repository(
             name = "com_github_reboot_dev_pyprotoc_plugin",

--- a/rules.bzl
+++ b/rules.bzl
@@ -57,7 +57,9 @@ def _protoc_plugin_rule_implementation(context):
 
     plugin_path = context.executable._plugin.path
     plugin_name = plugin_path.split("/")[-1]
-    plugin_short_name = plugin_name.replace("protoc-gen-", "")
+    if not plugin_name.startswith("protoc-gen-"):
+        fail("Plugin name %s does not start with protoc-gen-" % plugin_name)
+    plugin_short_name = plugin_name.removeprefix("protoc-gen-")
 
     args = [
         "--plugin=%s=%s" % (plugin_name, plugin_path),

--- a/rules.bzl
+++ b/rules.bzl
@@ -19,9 +19,8 @@ def _generate_output_names(context, proto_file):
         file_path = file_path[:-len(".proto")]
 
     output_file_names = [
-        "%s%s%s" % (
+        "%s%s" % (
             file_path,
-            "" if extension.startswith(".") else ".",
             extension,
         )
         for extension in context.attr._extensions

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -1,4 +1,6 @@
-load("@rules_python//python:defs.bzl", "py_test")
+load("@com_google_protobuf//:protobuf.bzl", "py_proto_library")
+load("@rules_python//python:defs.bzl", "py_binary", "py_test")
+load(":sample_rule.bzl", "py_sample_library")
 
 py_test(
     name = "library_tests",
@@ -7,5 +9,47 @@ py_test(
     ],
     deps = [
         "//pyprotoc_plugin",
+    ],
+)
+
+py_binary(
+    name = "protoc-gen-sample",
+    srcs = ["protoc-gen-sample.py"],
+    data = [":sample_template.j2"],
+    srcs_version = "PY3",
+    deps = [
+        "//pyprotoc_plugin",
+    ],
+)
+
+proto_library(
+    name = "sample_service_proto",
+    srcs = ["sample_service.proto"],
+)
+
+py_proto_library(
+    name = "sample_service_py_proto",
+    srcs = ["sample_service.proto"],
+)
+
+py_sample_library(
+    name = "sample_generated_library",
+    deps = [":sample_service_proto"],
+)
+
+# TODO(CodingCanuck, while-false): Why is this second library needed?
+py_library(
+    name = "sample_generated_library_py",
+    srcs = [":sample_generated_library"],
+)
+
+py_test(
+    name = "sample_generated_library_test",
+    srcs = [
+        "sample_generated_library_test.py",
+    ],
+    deps = [
+        ":sample_generated_library_py",
+        ":sample_service_py_proto",
     ],
 )

--- a/tests/protoc-gen-sample.py
+++ b/tests/protoc-gen-sample.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""A sample plugin to demonstrate the use of pyprotoc-plugin."""
+import os
+
+from google.protobuf.descriptor_pb2 import FileDescriptorProto
+
+from pyprotoc_plugin.helpers import load_template, add_template_path
+from pyprotoc_plugin.plugins import ProtocPlugin
+
+
+class SampleProtocPlugin(ProtocPlugin):
+
+    def process_file(self, proto_file: FileDescriptorProto):
+        proto_dir = os.path.dirname(proto_file.name)
+        template_data = {
+            'proto_package': proto_dir,
+            'proto_module': os.path.basename(proto_file.name).replace('.proto', '_pb2'),
+            'services': [
+                {
+                    'name': service.name,
+                    'methods': [
+                        {
+                            'name': method.name,
+                            'input_type': method.input_type,
+                            'output_type': method.output_type,
+                        }
+                        for method in service.method
+                    ],
+                }
+                for service in proto_file.service
+            ]
+        }
+
+        output_file_name = proto_file.name.replace('.proto', '_sample_generated_out.py')
+
+        template = load_template('sample_template.j2')
+        content = template.render(**template_data)
+        self.response.file.add(name=output_file_name, content=content)
+
+
+if __name__ == '__main__':
+    add_template_path(os.path.dirname(__file__))
+    SampleProtocPlugin.execute()

--- a/tests/sample_generated_library_test.py
+++ b/tests/sample_generated_library_test.py
@@ -1,0 +1,15 @@
+from tests.sample_service_sample_generated_out import SampleServiceCustomClient
+from tests import sample_service_pb2
+
+import unittest
+
+class TestSampleGeneratedLibrary(unittest.TestCase):
+    """Tests the sample python client we generated for a proto service."""
+
+    def test_generated_client(self):
+        client = SampleServiceCustomClient()
+        # We can call a generated (no-op) method.
+        client.CallSampleMethod(sample_service_pb2.SampleRequest())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/sample_rule.bzl
+++ b/tests/sample_rule.bzl
@@ -1,0 +1,10 @@
+"""
+A sample library rule generated using pyprotoc-plugin.
+"""
+
+load("//:rules.bzl", "create_protoc_plugin_rule")
+
+py_sample_library = create_protoc_plugin_rule(
+    plugin_label = "//tests:protoc-gen-sample",
+    extensions = ["_sample_generated_out.py"],
+)

--- a/tests/sample_service.proto
+++ b/tests/sample_service.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+message SampleRequest {}
+
+message SampleResponse {}
+
+service SampleService {
+  rpc SampleMethod(SampleRequest) returns (SampleResponse) {}
+}

--- a/tests/sample_template.j2
+++ b/tests/sample_template.j2
@@ -1,0 +1,10 @@
+from {{ proto_package }} import {{ proto_module }}
+
+{% for service in services %}
+class {{ service.name }}CustomClient:
+{% for method in service.methods %}
+
+    def Call{{ method.name }}(self, input: {{ proto_module }}{{ method.input_type }}) -> {{ proto_module }}{{ method.output_type }}:
+        pass
+{%- endfor %}
+{%- endfor %}


### PR DESCRIPTION
Add pyprotoc-plugin tests: sample python code gen
    
    Pre-work before adding tests to confirm that we can generate code for a
    subset of input files.
    
    Fixes https://github.com/reboot-dev/pyprotoc-plugin/issues/4

Breaking change: allow python outputs without dots
    
    Python module names can't contain dots, so don't require that callers
    specify filename suffixes that start with dots.

Generate errors on invalid plugin filenames
    
    This would've saved me ~20 minutes of debugging why my pyprotoc-plugin
    was allegedly not found.