### PR TITLE
Separate protos-to-generate from proto-deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ proto_library(
 cc_jonathan_library(
     name = "potato_jonathan_generated",
     visibility = ["//visibility:public"],
+    srcs = ["potato.proto"],
     deps = [
         ":potato_proto",
         # Well known protos should be included as deps in the

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -23,18 +23,34 @@ py_binary(
 )
 
 proto_library(
+    name = "sample_messages_proto",
+    srcs = ["sample_messages.proto"],
+)
+
+py_proto_library(
+    name = "sample_messages_py_proto",
+    srcs = ["sample_messages.proto"],
+)
+
+proto_library(
     name = "sample_service_proto",
     srcs = ["sample_service.proto"],
+    deps = [":sample_messages_proto"],
 )
 
 py_proto_library(
     name = "sample_service_py_proto",
     srcs = ["sample_service.proto"],
+    deps = [":sample_messages_py_proto"],
 )
 
 py_sample_library(
     name = "sample_generated_library",
-    deps = [":sample_service_proto"],
+    srcs = ["sample_service.proto"],
+    deps = [
+        ":sample_messages_proto",
+        ":sample_service_proto",
+    ],
 )
 
 # TODO(CodingCanuck, while-false): Why is this second library needed?

--- a/tests/protoc-gen-sample.py
+++ b/tests/protoc-gen-sample.py
@@ -9,11 +9,16 @@ from pyprotoc_plugin.plugins import ProtocPlugin
 
 
 class SampleProtocPlugin(ProtocPlugin):
+    """A sample plugin that generates clients for every input service."""
+    def __init__(self):
+        self._files_to_generate = []
+        self._message_imports = {}
 
     def process_file(self, proto_file: FileDescriptorProto):
-        proto_dir = os.path.dirname(proto_file.name)
-        template_data = {
-            'proto_package': proto_dir,
+        # Examine the proto file to find services and messages.
+        proto_data = {
+            'proto_name': proto_file.name,
+            'proto_package': os.path.dirname(proto_file.name),
             'proto_module': os.path.basename(proto_file.name).replace('.proto', '_pb2'),
             'services': [
                 {
@@ -21,8 +26,8 @@ class SampleProtocPlugin(ProtocPlugin):
                     'methods': [
                         {
                             'name': method.name,
-                            'input_type': method.input_type,
-                            'output_type': method.output_type,
+                            'input_type': method.input_type.removeprefix('.'),
+                            'output_type': method.output_type.removeprefix('.'),
                         }
                         for method in service.method
                     ],
@@ -31,11 +36,29 @@ class SampleProtocPlugin(ProtocPlugin):
             ]
         }
 
-        output_file_name = proto_file.name.replace('.proto', '_sample_generated_out.py')
+        # We'll produce clients for any files containing services.
+        if proto_data['services']:
+            self._files_to_generate.append(proto_data)
 
-        template = load_template('sample_template.j2')
-        content = template.render(**template_data)
-        self.response.file.add(name=output_file_name, content=content)
+        # Map messages to files.
+        for message in proto_file.message_type:
+            self._message_imports[message.name] = (
+                f'from {proto_data["proto_package"]}.{proto_data["proto_module"]} import {message.name}')
+
+
+    def finalize(self) -> None:
+        # Generate service clients.
+        for template_data in self._files_to_generate:
+            output_file_name = template_data['proto_name'].replace(
+                '.proto', '_sample_generated_out.py')
+            template_data['message_imports'] = '\n'.join(self._message_imports.values())
+
+            template = load_template('sample_template.j2')
+            content = template.render(**template_data)
+            self.response.file.add(name=output_file_name, content=content)
+
+        super().finalize()
+
 
 
 if __name__ == '__main__':

--- a/tests/sample_generated_library_test.py
+++ b/tests/sample_generated_library_test.py
@@ -1,5 +1,5 @@
 from tests.sample_service_sample_generated_out import SampleServiceCustomClient
-from tests import sample_service_pb2
+from tests import sample_messages_pb2
 
 import unittest
 
@@ -9,7 +9,7 @@ class TestSampleGeneratedLibrary(unittest.TestCase):
     def test_generated_client(self):
         client = SampleServiceCustomClient()
         # We can call a generated (no-op) method.
-        client.CallSampleMethod(sample_service_pb2.SampleRequest())
+        client.CallSampleMethod(sample_messages_pb2.SampleInput())
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/sample_messages.proto
+++ b/tests/sample_messages.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message SampleInput {}
+
+message SampleOutput {}

--- a/tests/sample_service.proto
+++ b/tests/sample_service.proto
@@ -1,9 +1,7 @@
 syntax = "proto3";
 
-message SampleRequest {}
-
-message SampleResponse {}
+import "tests/sample_messages.proto";
 
 service SampleService {
-  rpc SampleMethod(SampleRequest) returns (SampleResponse) {}
+  rpc SampleMethod(SampleInput) returns (SampleOutput) {}
 }

--- a/tests/sample_template.j2
+++ b/tests/sample_template.j2
@@ -1,10 +1,10 @@
-from {{ proto_package }} import {{ proto_module }}
+{{ message_imports }}
 
 {% for service in services %}
 class {{ service.name }}CustomClient:
 {% for method in service.methods %}
 
-    def Call{{ method.name }}(self, input: {{ proto_module }}{{ method.input_type }}) -> {{ proto_module }}{{ method.output_type }}:
+    def Call{{ method.name }}(self, input: {{ method.input_type }}) -> {{ method.output_type }}:
         pass
 {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
I think this is required to unblock https://github.com/reboot-dev/respect-api/issues/17,
where the generated code compiler might need a dependency list that's a
superset of the files it wants to generate code for. (In particular, the
set of output files != a 1:1 mapping to the set of dependencies: instead
it's a 1:1 mapping to the set of srcs).