### PR TITLE
Downgrade proto library to fix build error

### DIFF
--- a/bazel/repos.bzl
+++ b/bazel/repos.bzl
@@ -24,9 +24,11 @@ def repos(external = True, repo_mapping = {}):
         git_repository(
             name = "com_google_protobuf",
             remote = "https://github.com/protocolbuffers/protobuf",
-            # Release 3.20.0.
-            commit = "bc799d78f81115940eec953e2937245c70e3e6e4",
-            shallow_since = "1648147893 -0700",
+            # Release v3.19.4.
+            # TODO(codingcanuck): Update to a newer release after
+            # https://github.com/protocolbuffers/protobuf/issues/9688 is fixed.
+            commit = "22d0e265de7d2b3d2e9a00d071313502e7d4cccf",
+            shallow_since = "1643340956 -0800",
             repo_mapping = repo_mapping,
         )
 


### PR DESCRIPTION
https://github.com/protocolbuffers/protobuf/issues/9688 caused build
errors when trying to integrate the latest `pyprotoc-plugin` changes
into https://github.com/3rdparty/eventuals.

Fixes build errors of the form:
```
ERROR: /home/vscode/.cache/dazel/tests/external/com_envoyproxy_protoc_gen_validate/validate/BUILD:28:17: Label '@com_google_protobuf//:protobuf_python' is duplicated in the 'deps' attribute of rule 'validate_py'
ERROR: /home/vscode/.cache/dazel/tests/external/envoy_api/envoy/extensions/filters/network/http_connection_manager/v3/BUILD:7:18: Target '@com_envoyproxy_protoc_gen_validate//validate:validate_proto' contains an error and its package is in error and referenced by '@envoy_api//envoy/extensions/filters/network/http_connection_manager/v3:pkg'
INFO: Repository com_github_curl_curl instantiated at:
  /workspaces/respect/submodules/eventuals/WORKSPACE.bazel:26:5: in <toplevel>
  /workspaces/respect/submodules/eventuals/bazel/deps.bzl:24:14: in deps
  /home/vscode/.cache/dazel/tests/external/com_github_3rdparty_bazel_rules_curl/bazel/deps.bzl:30:10: in deps
  /home/vscode/.cache/dazel/tests/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
Repository rule http_archive defined at:
  /home/vscode/.cache/dazel/tests/external/bazel_tools/tools/build_defs/repo/http.bzl:364:31: in <toplevel>
ERROR: Analysis of target '//test:death-client' failed; build aborted:
```
