### PR TITLE
Document minimum required Python version (3.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,9 @@
 The package provides a small `python3` library as well as some `bazel` templates to
 make it easier for developers using `bazel` to write `protoc` plugins and generate custom code from protobuf files.
 
+## Requirements
+`pyprotoc_plugin` works with Python `>=3.9`.
+
 ## Creating a plugin
 
 A `protoc` plugin is any executable, named `protoc-gen-.*`, that can read and write `protoc` compatible input and output from `stdin` and `stdout`.


### PR DESCRIPTION
We require Python 3.9, or we'll get errors like [this](https://github.com/reboot-dev/pyprotoc-plugin/runs/6192366369?check_suite_focus=true):

> File "/home/runner/.cache/bazel/_bazel_runner/6fe01d19795f[87](https://github.com/reboot-dev/pyprotoc-plugin/runs/6192366369?check_suite_focus=true#step:4:87)79367b504b29876616/sandbox/linux-sandbox/392/execroot/com_github_reboot_dev_pyprotoc_plugin/bazel-out/host/bin/tests/protoc-gen-sample.runfiles/com_github_reboot_dev_pyprotoc_plugin/tests/protoc-gen-sample.py", line 29, in <listcomp>
    'input_type': method.input_type.removeprefix('.'),
AttributeError: 'str' object has no attribute 'removeprefix'