### PR TITLE
Introduce code format checking.

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+submodules/dev-tools/.clang-format

--- a/.github/workflows/check_code_style.yml
+++ b/.github/workflows/check_code_style.yml
@@ -1,0 +1,39 @@
+name: Check Code Style
+
+# We use action's triggers 'push' and 'pull_request'.
+# The strategy is the following: this action will be
+# triggered on any push to 'main' branch and any pull
+# request to any branch. Thus we avoid duplicate work-
+# flows.
+on:
+  push:
+    branches:
+      - "main"
+  pull_request:
+    branches:
+      - "**"
+
+jobs:
+  check_code_style:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: ["ubuntu-latest"]
+
+    steps:
+      # We should checkout the repo with submodules
+      # cause we need to have symlink to
+      # dev-tools/.clang-format file for all code
+      # style checks.
+      - uses: actions/checkout@v2
+        with:
+          # We don't need special credentials since this is a public repo
+          # that only depends on other public repos.
+          submodules: "recursive"
+
+      # Call the composite action to check files
+      # for correct code style. This action (action.yml)
+      # is in `dev-tools` submodule.
+      - uses: ./submodules/dev-tools/check-code-style
+        with:
+          os: ${{matrix.os}}

--- a/.github/workflows/pre-merge-checks.yml
+++ b/.github/workflows/pre-merge-checks.yml
@@ -16,6 +16,10 @@ jobs:
     steps:
       - name: Checkout reboot-dev/pyprotoc-plugin
         uses: actions/checkout@v2
+        with:
+          # We don't need special credentials since this is a public repo
+          # that only depends on other public repos.
+          submodules: recursive
       - name: Install Python 3.9 and set it as the default
         # To set Python 3.9 as the default we use `update-alternatives`:
         #   https://linux.die.net/man/8/update-alternatives

--- a/.github/workflows/submodules-sync.yml
+++ b/.github/workflows/submodules-sync.yml
@@ -1,0 +1,25 @@
+# The workflow calls another workflow
+# See docs:
+# https://docs.github.com/en/actions/using-workflows/reusing-workflows
+name: Submodules Sync
+
+on:
+  # Run this workflow every 15 minutes.
+  schedule:
+    - cron: "0/15 * * * *"
+  # Allows you to run this workflow manually from the Actions tab or through
+  # the HTTP API.
+  workflow_dispatch:
+
+jobs:
+  submodule-sync:
+    uses: 3rdparty/dev-tools/.github/workflows/submodules-sync.yml@main
+    with:
+      devtools_directory: submodules/dev-tools
+    secrets:
+      # TODO: the name for this secret suggests that this MUST be a credential
+      # for reboot-dev-bot and MUST be able to access private repos, but that
+      # isn't the case for us: we have no private repos to access, so passing
+      # the regular GITHUB_TOKEN is fine. We should send a PR to `dev-tools`
+      # to improve the wording.
+      private_repo_access_as_rebot_token: ${{ GITHUB_TOKEN }}

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "submodules/dev-tools"]
+	path = submodules/dev-tools
+	url = https://github.com/3rdparty/dev-tools.git
+	branch = main

--- a/.style.yapf
+++ b/.style.yapf
@@ -1,0 +1,1 @@
+./submodules/dev-tools/.style.yapf

--- a/pyprotoc_plugin/helpers.py
+++ b/pyprotoc_plugin/helpers.py
@@ -3,7 +3,6 @@ import os
 
 from jinja2 import Template, StrictUndefined
 
-
 ENV_TEMPLATE_PATH = 'TEMPLATE_PATH'
 
 
@@ -12,32 +11,27 @@ def resolve_template_path(template_name: str) -> str:
 
     template_path = os.environ.get(ENV_TEMPLATE_PATH, None)
     if template_path is None:
-        template_path = ':'.join([
-            '.',
-            os.path.join(__file__, '..'),
-            os.path.join(__file__, '../templates/')
-        ])
+        template_path = ':'.join(
+            [
+                '.',
+                os.path.join(__file__, '..'),
+                os.path.join(__file__, '../templates/')
+            ]
+        )
 
     valid_paths = [
-        os.path.abspath(path)
-        for path in
-        [
+        os.path.abspath(path) for path in [
             os.path.join(path_segment, template_name)
-            for path_segment in
-            template_path.split(':')
-        ]
-        if os.path.exists(path)
+            for path_segment in template_path.split(':')
+        ] if os.path.exists(path)
     ]
 
     if len(valid_paths) == 0:
         print(
             [
-                os.path.abspath(path)
-                for path in
-                [
+                os.path.abspath(path) for path in [
                     os.path.join(path_segment, template_name)
-                    for path_segment in
-                    template_path.split(':')
+                    for path_segment in template_path.split(':')
                 ]
             ],
             file=sys.stderr
@@ -53,10 +47,7 @@ def add_template_path(path: str) -> None:
     template_path = os.environ.get(ENV_TEMPLATE_PATH, '')
 
     new_template_path = ':'.join(
-        p
-        for p in
-        [os.path.abspath(path), template_path]
-        if len(p)
+        p for p in [os.path.abspath(path), template_path] if len(p)
     )
 
     print(

--- a/pyprotoc_plugin/plugins.py
+++ b/pyprotoc_plugin/plugins.py
@@ -21,9 +21,7 @@ class ProtocPlugin(object):
         self.response = plugin.CodeGeneratorResponse()
 
     def finalize(self) -> None:
-        sys.stdout.buffer.write(
-            self.response.SerializeToString()
-        )
+        sys.stdout.buffer.write(self.response.SerializeToString())
 
     def run(self) -> None:
         for proto_file in self.request.proto_file:

--- a/rules.bzl
+++ b/rules.bzl
@@ -32,13 +32,13 @@ def _declare_outputs(context):
             for output_file in _generate_output_names(context, proto_file):
                 output_files.append(
                     context.actions.declare_file(
-                       output_file,
-                       sibling = proto_file,
+                        output_file,
+                        sibling = proto_file,
                     ),
                 )
         else:
             output_files.append(
-                context.actions.declare_directory(proto_file.basename.removesuffix('.proto') + '_generated')
+                context.actions.declare_directory(proto_file.basename.removesuffix(".proto") + "_generated"),
             )
 
     return output_files
@@ -52,8 +52,8 @@ def _protoc_plugin_rule_implementation(context):
     if not context.attr._extensions:
         # Declare a directory on one level upper to generated ones, to be sure
         # it works with a couple proto files.
-        output_directory = "/".join(output_files[0].path.split('/')[:-1])
-    
+        output_directory = "/".join(output_files[0].path.split("/")[:-1])
+
     if len(context.label.workspace_root) != 0:
         output_directory += "/" + context.label.workspace_root
 
@@ -67,7 +67,7 @@ def _protoc_plugin_rule_implementation(context):
     args = [
         "--plugin=%s=%s" % (plugin_name, plugin_path),
         "--%s_out" % plugin_short_name,
-        output_directory
+        output_directory,
     ]
 
     _virtual_imports = "/_virtual_imports/"

--- a/rules.bzl
+++ b/rules.bzl
@@ -137,13 +137,13 @@ def create_protoc_plugin_rule(plugin_label, extensions = []):
                 default = extensions,
             ),
             "_plugin": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 default = Label(plugin_label),
                 # allow_single_file=True,
                 executable = True,
             ),
             "_protoc": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 default = Label("@com_google_protobuf//:protoc"),
                 executable = True,
                 allow_single_file = True,

--- a/tests/cpp/BUILD.bazel
+++ b/tests/cpp/BUILD.bazel
@@ -1,7 +1,7 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load(":cpp_rule.bzl", "cc_generate_library")
 load("@rules_python//python:defs.bzl", "py_binary")
+load(":cpp_rule.bzl", "cc_generate_library")
 
 py_binary(
     name = "protoc-gen-headers",

--- a/tests/cpp/BUILD.bazel
+++ b/tests/cpp/BUILD.bazel
@@ -26,11 +26,13 @@ proto_library(
 cc_generate_library(
     name = "cc_generated_proto",
     srcs = [
+        "another_service.proto",
         "sample_service.proto",
-        "another_service.proto"],
+    ],
     deps = [
+        ":another_service_proto",
         ":sample_service_proto",
-        ":another_service_proto"],
+    ],
 )
 
 cc_proto_library(
@@ -47,9 +49,9 @@ cc_library(
     name = "cc_library_generated",
     hdrs = [":cc_generated_proto"],
     deps = [
+        ":another_service_cc_proto",
         ":sample_service_cc_proto",
-        ":another_service_cc_proto"
-    ]
+    ],
 )
 
 cc_binary(
@@ -57,5 +59,5 @@ cc_binary(
     srcs = ["cc_generated_test.cc"],
     deps = [
         ":cc_library_generated",
-    ]
+    ],
 )

--- a/tests/cpp/another_service.proto
+++ b/tests/cpp/another_service.proto
@@ -1,6 +1,6 @@
 syntax = "proto3";
 
-message Input{}
+message Input {}
 
 message Output {
   int32 value = 1;

--- a/tests/cpp/protoc-gen-headers.py
+++ b/tests/cpp/protoc-gen-headers.py
@@ -11,44 +11,53 @@ from pyprotoc_plugin.plugins import ProtocPlugin
 
 class SampleCppProtocPlugin(ProtocPlugin):
     """A sample plugin that generates clients for every input service."""
+
     def __init__(self):
         self._files_to_generate = []
 
     def process_file(self, proto_file: FileDescriptorProto):
         # Examine the proto file to find services and messages.
         proto_data = {
-            'proto_name': proto_file.name,
-            'services': [
-                {
-                    'name': service.name,
-                    'methods': [
-                        {
-                            'name': method.name,
-                            'input_type': method.input_type.removeprefix('.'),
-                            'output_type': method.output_type.removeprefix('.'),
-                        }
-                        for method in service.method
-                    ],
-                }
-                for service in proto_file.service
-            ]
+            'proto_name':
+                proto_file.name,
+            'services':
+                [
+                    {
+                        'name':
+                            service.name,
+                        'methods':
+                            [
+                                {
+                                    'name':
+                                        method.name,
+                                    'input_type':
+                                        method.input_type.removeprefix('.'),
+                                    'output_type':
+                                        method.output_type.removeprefix('.'),
+                                } for method in service.method
+                            ],
+                    } for service in proto_file.service
+                ]
         }
 
         # We'll produce clients for any files containing services.
         if proto_data['services']:
             self._files_to_generate.append(proto_data)
-        
 
     def finalize(self) -> None:
         # Generate service clients.
         for template_data in self._files_to_generate:
             output_file_dir = template_data['proto_name'].replace(
-                '.proto', '_generated').split('/')[-1]
+                '.proto', '_generated'
+            ).split('/')[-1]
 
             template = load_template('cpp_template.j2')
             content = template.render(
-                include_path = template_data['proto_name'].replace('.proto', '.pb.h'),
-                **template_data)
+                include_path=template_data['proto_name'].replace(
+                    '.proto', '.pb.h'
+                ),
+                **template_data
+            )
 
             # Equals to 'proto_file_name_generated.h'
             output_file_name = output_file_dir + '.h'
@@ -56,7 +65,7 @@ class SampleCppProtocPlugin(ProtocPlugin):
             output_file_path = output_file_dir + '/' + output_file_name
 
             self.response.file.add(name=output_file_path, content=content)
-        
+
         super().finalize()
 
 

--- a/tests/python/library_tests.py
+++ b/tests/python/library_tests.py
@@ -1,10 +1,8 @@
-
 import jinja2
 import google.protobuf
 import pyprotoc_plugin
 
 import pyprotoc_plugin.helpers
 from pyprotoc_plugin.helpers import load_template
-
 
 print('All imports tested.')

--- a/tests/python/protoc-gen-sample.py
+++ b/tests/python/protoc-gen-sample.py
@@ -21,7 +21,7 @@ class SampleProtocPlugin(ProtocPlugin):
             'proto_name':
                 proto_file.name,
             'proto_package':
-                os.path.dirname(proto_file.name),
+                os.path.dirname(proto_file.name).replace('/', '.'),
             'proto_module':
                 os.path.basename(proto_file.name).replace('.proto', '_pb2'),
             'services':

--- a/tests/python/sample_generated_library_test.py
+++ b/tests/python/sample_generated_library_test.py
@@ -3,6 +3,7 @@ from tests.python import sample_messages_pb2
 
 import unittest
 
+
 class TestSampleGeneratedLibrary(unittest.TestCase):
     """Tests the sample python client we generated for a proto service."""
 
@@ -10,6 +11,7 @@ class TestSampleGeneratedLibrary(unittest.TestCase):
         client = SampleServiceCustomClient()
         # We can call a generated (no-op) method.
         client.CallSampleMethod(sample_messages_pb2.SampleInput())
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Before this PR, there was no automated checking of code style as part of
our GitHub checks. This PR introduces a new GitHub check that uses our
standard `dev-tools` tooling to check the code style of the codebase.

This requires the following changes:
1. Introduces `dev-tools` as a submodule, and adds a `submodule-sync`
   workflow to keep it up to date.
2. Adds `.clang-format` and `.style.yapf` symlinks.
3. Adds a `check_code_style.yml` workflow (copied verbatim from
   `3rdparty/eventuals`) to trigger the checks in `dev-tools`.
4. Fixes `rules.bzl` to pass the `dev-tools` check (it was failing with
   Buildifier 5.1.0 but passed our old Buildifier 4.2.5).
5. Fixes `*.py` to pass the `dev-tools` check.

Fixes https://github.com/reboot-dev/pyprotoc-plugin/issues/15