### PR TITLE
Switch bazel remote cache to a multi-region bucket

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,6 +1,6 @@
 # Use a remote build cache that's world-readable. Don't write unless told otherwise.
 
-build --remote_cache=https://storage.googleapis.com/reboot-workstations-buildcache
+build --remote_cache=https://storage.googleapis.com/reboot-dev-bazel-remote-cache-reboot-us
 build --remote_upload_local_results=false
 
 # Print full test logs for failed tests.


### PR DESCRIPTION
This should hopefully reduce the number of timeouts we're seeing when
running builds from systems in various locations. e.g. per
https://github.com/reboot-dev/respect/issues/698#issuecomment-1195302008
this should allow builds run from GitHub Codespaces (and presumably
GitHub Actions Runner) to access a remote cache storage bucket that's
closer to that system, which should hopefully reduce network latency and
improve reliability.

TESTED=`bazel test //...` works from my codespace.
