### PR TITLE
Configure Jinja whitespace options.

### DIFF
--- a/pyprotoc_plugin/helpers.py
+++ b/pyprotoc_plugin/helpers.py
@@ -1,7 +1,6 @@
-import sys
 import os
-
-from jinja2 import Template, StrictUndefined
+import sys
+from jinja2 import StrictUndefined, Template
 
 ENV_TEMPLATE_PATH = 'TEMPLATE_PATH'
 
@@ -66,4 +65,5 @@ def load_template(template_name: str) -> Template:
         return Template(
             template_file.read(),
             undefined=StrictUndefined,
+            trim_blocks=True,
         )

--- a/pyprotoc_plugin/helpers.py
+++ b/pyprotoc_plugin/helpers.py
@@ -57,7 +57,7 @@ def add_template_path(path: str) -> None:
     os.environ[ENV_TEMPLATE_PATH] = new_template_path
 
 
-def load_template(template_name: str) -> Template:
+def load_template(template_name: str, **template_options) -> Template:
     template_path = resolve_template_path(template_name) \
         if not os.path.exists(template_name) else template_name
 
@@ -65,5 +65,5 @@ def load_template(template_name: str) -> Template:
         return Template(
             template_file.read(),
             undefined=StrictUndefined,
-            trim_blocks=True,
+            **template_options,
         )


### PR DESCRIPTION
Before this PR, for an input like:
```jinja
{% if True %}
Hello
{% endif %}
```

... our Jinja would always output:
```

Hello

```

When often what a user (like ourselves in other repos) wants is:
```
Hello
```

This PR allows users to access Jinja's whitespace control options, as well as other jinja settings, to make the output look as desired. This helps us generate cleaner-reading code with cleaner-looking templates.