### PR TITLE
Support `optional` fields

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,1 @@
+./submodules/dev-tools/.isort.cfg

--- a/pyprotoc_plugin/plugins.py
+++ b/pyprotoc_plugin/plugins.py
@@ -1,5 +1,4 @@
 import sys
-
 from google.protobuf.compiler import plugin_pb2 as plugin
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
 from google.protobuf.descriptor_pool import DescriptorPool

--- a/pyprotoc_plugin/plugins.py
+++ b/pyprotoc_plugin/plugins.py
@@ -19,7 +19,13 @@ class ProtocPlugin(object):
             sys.stdin.buffer.read()
         )
 
-        self.response = plugin.CodeGeneratorResponse()
+        self.response = plugin.CodeGeneratorResponse(
+            # Since `pyprotoc_plugin` was introduced after proto3 added the
+            # `optional` keyword, we assume that all plugins built using this
+            # library are compatible with `optional` fields.
+            supported_features=plugin.CodeGeneratorResponse.
+            FEATURE_PROTO3_OPTIONAL
+        )
 
         self.pool = DescriptorPool()
         for proto_file in self.request.proto_file:

--- a/tests/cpp/protoc-gen-headers.py
+++ b/tests/cpp/protoc-gen-headers.py
@@ -2,10 +2,8 @@
 """A sample plugin to demonstrate the use of pyprotoc-plugin."""
 import os
 import sys
-
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
-
-from pyprotoc_plugin.helpers import load_template, add_template_path
+from pyprotoc_plugin.helpers import add_template_path, load_template
 from pyprotoc_plugin.plugins import ProtocPlugin
 
 

--- a/tests/cpp/sample_service.proto
+++ b/tests/cpp/sample_service.proto
@@ -4,6 +4,7 @@ message Request {}
 
 message Response {
   string data = 1;
+  optional string details = 2;
 }
 
 service SampleService {

--- a/tests/python/library_tests.py
+++ b/tests/python/library_tests.py
@@ -1,7 +1,6 @@
-import jinja2
 import google.protobuf
+import jinja2
 import pyprotoc_plugin
-
 import pyprotoc_plugin.helpers
 from pyprotoc_plugin.helpers import load_template
 

--- a/tests/python/protoc-gen-sample.py
+++ b/tests/python/protoc-gen-sample.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 """A sample plugin to demonstrate the use of pyprotoc-plugin."""
 import os
-
 from google.protobuf.descriptor_pb2 import FileDescriptorProto
-
-from pyprotoc_plugin.helpers import load_template, add_template_path
+from pyprotoc_plugin.helpers import add_template_path, load_template
 from pyprotoc_plugin.plugins import ProtocPlugin
 
 

--- a/tests/python/sample_generated_library_test.py
+++ b/tests/python/sample_generated_library_test.py
@@ -1,7 +1,8 @@
-from tests.python.sample_service_sample_generated_out import SampleServiceCustomClient
-from tests.python import sample_messages_pb2
-
 import unittest
+from tests.python import sample_messages_pb2
+from tests.python.sample_service_sample_generated_out import (
+    SampleServiceCustomClient,
+)
 
 
 class TestSampleGeneratedLibrary(unittest.TestCase):


### PR DESCRIPTION
Before this PR, a proto file containing an `optional` field would cause a pyprotoc plugin to fail, with an error along the lines of:

> tests/cpp/sample_service.proto: is a proto3 file that contains
> optional fields, but code generator protoc-gen-headers hasn't been
> updated to support optional fields in proto3. Please ask the owner of
> this code generator to support proto3 optional.--headers_out:oneof

This PR adds support for `optional` fields, by simply telling `protoc` that we support them. Since `pyprotoc-plugin` doesn't itself generate any code, actual support of `optional` fields is up to the developers building pyprotoc plugins. Since `optional` fields have been a supported feature of proto3 [for >2 years now](
https://github.com/protocolbuffers/protobuf/releases/tag/v3.15.0) we believe that it is reasonable to assume that developers are aware of the need to support them, just like any other type of field. Therefore we believe it is reasonable to declare support for `optional` by default (we also don't ask developers if they support `repeated` fields, after all).

Fixes #29