### PR TITLE
Prevent log spam during successful build

### DIFF
--- a/pyprotoc_plugin/helpers.py
+++ b/pyprotoc_plugin/helpers.py
@@ -49,11 +49,6 @@ def add_template_path(path: str) -> None:
         p for p in [os.path.abspath(path), template_path] if len(p)
     )
 
-    print(
-        f'Adding template path: {os.path.abspath(new_template_path)}',
-        file=sys.stderr
-    )
-
     os.environ[ENV_TEMPLATE_PATH] = new_template_path
 
 


### PR DESCRIPTION
In the past, while we were frequently debugging the `pyprotoc_plugin` and the plugins we were building with it, it was useful to have a `print` statement that informed us about every template we'd ever use to generate code.

Now, we're moving towards our customers using these plugins, and this log message is only confusing. Customers don't know that our plugins are built around templates, and the print statement makes it look like there's an error or warning during their proto compilation, which there isn't.

Therefore, it's time to remove the print statement.