### PR TITLE
bazel: handle generated protos from external repos

### DIFF
--- a/.mergequeue/config.yml
+++ b/.mergequeue/config.yml
@@ -1,0 +1,32 @@
+version: 1.0.0
+merge_rules:
+  labels:
+    trigger: mergequeue-ready
+    skip_line: ""
+    merge_failed: ""
+    skip_delete_branch: ""
+  update_latest: true
+  delete_branch: false
+  use_rebase: true
+  enable_comments: true
+  ci_timeout_mins: 0
+  preconditions:
+    number_of_approvals: 1
+    required_checks: []
+    use_github_mergeability: false
+    conversation_resolution_required: true
+  merge_mode:
+    type: default
+    parallel_mode: null
+  auto_update:
+    enabled: false
+    label: ""
+    max_runs_for_update: 0
+  merge_commit:
+    use_title_and_body: false
+  merge_strategy:
+    name: squash
+    override_labels:
+      squash: ""
+      merge: ""
+      rebase: mergequeue-rebase


### PR DESCRIPTION
When pyprotoc is used through an external repository, generated proto files can arrive with a path/short_path mismatch:

- path: bazel-out/.../external/<repo>/...
- short_path: ../<repo>/...

The previous logic in `rules.bzl` did not match this shape and fell through to "Handling this type of (generated?) .proto file was not forseen".

This commit adds a narrow branch in the existing proto loop to normalize this short_path form to a repo-relative path and emit the corresponding `-I` + input proto args.

This keeps existing behavior for local files, external source files, and `_virtual_imports`, while fixing generated protos from external repos.